### PR TITLE
ENH: populate crosswalktable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-DSCI_Anonymize/__pycache__/DSCI_Anonymize.cpython-36.pyc
-DSCI_Anonymize/__pycache__/DSCI_Anonymize.cpython-36.pyc
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+DSCI_Anonymize/__pycache__/DSCI_Anonymize.cpython-36.pyc
+DSCI_Anonymize/__pycache__/DSCI_Anonymize.cpython-36.pyc

--- a/DSCI_Anonymize/DSCI_Anonymize.py
+++ b/DSCI_Anonymize/DSCI_Anonymize.py
@@ -56,7 +56,6 @@ class DSCI_AnonymizeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.logic = None
     self._parameterNode = None
     self._updatingGUIFromParameterNode = False
-    print("In init")
     self.input_image_list = {}
     self.output_dir = None
     self.setParameterNode(None)
@@ -65,7 +64,6 @@ class DSCI_AnonymizeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     """
     Called when the user opens the module the first time and the widget is initialized.
     """
-    print("In setup ", len(self.input_image_list))
     ScriptedLoadableModuleWidget.setup(self)
 
     # Load widget from .ui file (created by Qt Designer).
@@ -135,7 +133,6 @@ class DSCI_AnonymizeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # third element keeps track of manual edits. False: auto, True is manual
         self.input_image_list[d] = [idx,"", False]
     self.updateParameterNodeFromGUI()
-    print(self.input_image_list)
 
   def onOutputDirChanged(self, dir_name):
     output_dir = Path(str(dir_name))
@@ -156,7 +153,6 @@ class DSCI_AnonymizeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     Called each time the user opens this module.
     """
     # Make sure parameter node exists and observed
-    print("In enter")
     self.initializeParameterNode()
 
   def exit(self):
@@ -171,7 +167,7 @@ class DSCI_AnonymizeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     Called just before the scene is closed.
     """
     # Parameter node will be reset, do not use it anymore
-    print("In on scene starting to close")
+    self.input_image_list={}
     self.setParameterNode(None)
 
   def onSceneEndClose(self, caller, event):
@@ -180,7 +176,6 @@ class DSCI_AnonymizeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     """
     # If this module is shown while the scene is closed then recreate a new parameter node immediately
     if self.parent.isEntered:
-      print("Parent entered")
       self.initializeParameterNode()
 
   def initializeParameterNode(self):
@@ -189,7 +184,6 @@ class DSCI_AnonymizeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     """
     # Parameter node stores all user choices in parameter values, node selections, etc.
     # so that when the scene is saved and reloaded, these settings are restored.
-    print("initialize parameter node")
     self.setParameterNode(self.logic.getParameterNode())
 
   def setParameterNode(self, inputParameterNode):
@@ -208,7 +202,6 @@ class DSCI_AnonymizeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     if self._parameterNode is not None:
       self.addObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGUIFromParameterNode)
     # Initial GUI update
-    print("In setparameternode")
     self.updateGUIFromParameterNode()
 
   def updateGUIFromParameterNode(self, caller=None, event=None):
@@ -223,7 +216,6 @@ class DSCI_AnonymizeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self._updatingGUIFromParameterNode = True
 
     # Update node selectors and sliders
-    print("Who is calling me?")
     print(self._parameterNode.GetParameter("InListDetailsString"))
     self.ui.inDetailsLabel.setText(self._parameterNode.GetParameter("InListDetailsString"))
     self.ui.useUUIDCheckBox.checked = (self._parameterNode.GetParameter("UseUUID") == "true")
@@ -250,12 +242,8 @@ class DSCI_AnonymizeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       for k in self.input_image_list:
         entry =  self.input_image_list[k]
         index = entry[0]
-        print("index: {}".format(index))
-        out_format = self._parameterNode.GetParameter("OutputFormat")
         if entry[2]:
           # Filename was edited manually.
-          print("File name was edited manually, does it have output format?")
-          # Make sure that the filename has an output format.
           filename = entry[1]
         elif (self._parameterNode.GetParameter("UseUUID") == "true"):
           filename = str(uuid.uuid4())
@@ -280,7 +268,6 @@ class DSCI_AnonymizeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     This method is called when the user makes any change in the GUI.
     The changes are saved into the parameter node (so that they are restored when the scene is saved and loaded).
     """
-    print('Called')
     if self._parameterNode is None or self._updatingGUIFromParameterNode:
       return
 

--- a/DSCI_Anonymize/DSCI_Anonymize.py
+++ b/DSCI_Anonymize/DSCI_Anonymize.py
@@ -350,7 +350,10 @@ class DSCI_AnonymizeLogic(ScriptedLoadableModuleLogic):
               else:
                 filename = (prefix+ "_%04d"%idx + out_format)
               out_path = output_dir / filename
-              slicer.util.saveNode(image_node, str(out_path))
+              if out_format == ".dcm":
+                slicer.util.errorDisplay("Export to dicom format still not supported")
+              else:
+                slicer.util.saveNode(image_node, str(out_path))
             except Exception as e:
               logging.error("Error reading/writing file: {}".format(imgpath))
               if image_node is not None:

--- a/DSCI_Anonymize/DSCI_Anonymize.py
+++ b/DSCI_Anonymize/DSCI_Anonymize.py
@@ -107,11 +107,9 @@ class DSCI_AnonymizeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       return
     # Get the list of images:
     input_image_list = []
-    input_pattern = self.ui.inputFormatComboBox.currentText
-    print("Will look for: ", input_pattern)
-    print("Splitted patterns: ", input_pattern.split(','))
+    input_pattern = self.ui.inputFormatComboBox.currentText.split(',')
     for pattern in input_pattern:
-      input_image_list.extend( list(input_path.glob("**/*" + pattern)))
+      input_image_list.extend( list(input_path.glob("**/" + pattern)))
     dir_set = set()
     if len(input_image_list) > 0:
       for im in input_image_list:
@@ -140,7 +138,6 @@ class DSCI_AnonymizeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     Called each time the user opens this module.
     """
     # Make sure parameter node exists and observed
-    print('In enter')
     self.initializeParameterNode()
 
   def exit(self):
@@ -163,7 +160,6 @@ class DSCI_AnonymizeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     """
     # If this module is shown while the scene is closed then recreate a new parameter node immediately
     if self.parent.isEntered:
-      print("Scene is closed")
       self.initializeParameterNode()
 
   def initializeParameterNode(self):
@@ -172,7 +168,6 @@ class DSCI_AnonymizeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     """
     # Parameter node stores all user choices in parameter values, node selections, etc.
     # so that when the scene is saved and reloaded, these settings are restored.
-    print("Setting parameter node.")
     self.setParameterNode(self.logic.getParameterNode())
 
   def setParameterNode(self, inputParameterNode):
@@ -181,10 +176,7 @@ class DSCI_AnonymizeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     Observation is needed because when the parameter node is changed then the GUI must be updated immediately.
     """
     if inputParameterNode:
-      print("Setting default parameters?")
       self.logic.setDefaultParameters(inputParameterNode)
-    else:
-      print("Not setting default parameters")
     # Unobserve previously selected parameter node and add an observer to the newly selected.
     # Changes of parameter node are observed so that whenever parameters are changed by a script or any other module
     # those are reflected immediately in the GUI.
@@ -354,9 +346,9 @@ class DSCI_AnonymizeLogic(ScriptedLoadableModuleLogic):
               loadable = scalarVolumeReader.examineForImport([files])[0]
               image_node = scalarVolumeReader.load(loadable)
               if useUUID:
-                filename = str(uuid.uuid4()) + ".nrrd"
+                filename = str(uuid.uuid4()) + out_format
               else:
-                filename = (prefix+ "_%04d"%idx + ".nrrd")
+                filename = (prefix+ "_%04d"%idx + out_format)
               out_path = output_dir / filename
               slicer.util.saveNode(image_node, str(out_path))
             except Exception as e:

--- a/DSCI_Anonymize/Resources/UI/DSCI_Anonymize.ui
+++ b/DSCI_Anonymize/Resources/UI/DSCI_Anonymize.ui
@@ -45,7 +45,7 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QComboBox" name="inputFormat_ComboBox">
+       <widget class="QComboBox" name="inputFormatComboBox">
         <item>
          <property name="text">
           <string>*.dcm,*.dicom, *.DICOM,*.DCM</string>
@@ -92,7 +92,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="outputFormat_ComboBox">
+         <widget class="QComboBox" name="outputFormatComboBox">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>

--- a/DSCI_Anonymize/Resources/UI/DSCI_Anonymize.ui
+++ b/DSCI_Anonymize/Resources/UI/DSCI_Anonymize.ui
@@ -114,11 +114,6 @@
             <string>.nrrd</string>
            </property>
           </item>
-          <item>
-           <property name="text">
-            <string>.dcm</string>
-           </property>
-          </item>
          </widget>
         </item>
        </layout>

--- a/DSCI_Anonymize/Resources/UI/DSCI_Anonymize.ui
+++ b/DSCI_Anonymize/Resources/UI/DSCI_Anonymize.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>527</width>
-    <height>257</height>
+    <width>469</width>
+    <height>463</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -20,7 +20,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Input Directory with DICOMs: </string>
+         <string>Input Directory:   </string>
         </property>
        </widget>
       </item>
@@ -30,11 +30,11 @@
          <string>Select directory with DICOMs</string>
         </property>
         <property name="toolTipDuration">
-         <number>5</number>
+         <number>10</number>
         </property>
        </widget>
       </item>
-      <item row="1" column="0" colspan="2">
+      <item row="3" column="0" colspan="2">
        <widget class="QLabel" name="inDetailsLabel">
         <property name="text">
          <string>No directory selected</string>
@@ -42,6 +42,15 @@
         <property name="alignment">
          <set>Qt::AlignCenter</set>
         </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="inputFormat_ComboBox">
+        <item>
+         <property name="text">
+          <string>*.dcm,*.dicom, *.DICOM,*.DCM</string>
+         </property>
+        </item>
        </widget>
       </item>
      </layout>
@@ -70,6 +79,50 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLineEdit" name="prefixLineEdit">
+          <property name="toolTip">
+           <string>Files will be renamed with this prefix, if UUID is not requested</string>
+          </property>
+          <property name="toolTipDuration">
+           <number>5</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="outputFormat_ComboBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <item>
+           <property name="text">
+            <string>.nii.gz</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>.gipl</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>.nrrd</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>.dcm</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
+      </item>
       <item row="1" column="0">
        <widget class="QCheckBox" name="useUUIDCheckBox">
         <property name="toolTip">
@@ -83,14 +136,28 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QLineEdit" name="prefixLineEdit">
-        <property name="toolTip">
-         <string>Files will be renamed with this prefix, if UUID is not requested</string>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleButton" name="crosswalkCollapsibleButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Preview Crosswalk</string>
+     </property>
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0" colspan="2">
+       <widget class="QTableWidget" name="crosswalkTableWidget">
+        <property name="columnCount">
+         <number>2</number>
         </property>
-        <property name="toolTipDuration">
-         <number>5</number>
-        </property>
+        <column/>
+        <column/>
        </widget>
       </item>
      </layout>


### PR DESCRIPTION
With this pull request:
- A table for crosswalk is populated with a preview of the images, and their target filenames
- Users can change any filename in the crosswalk table
- Users can also change the prefix, and see the name changes on the fly
- A few bug fixes. 