### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(SlicerBatchAnonymize)
 # Extension meta-information
 set(EXTENSION_HOMEPAGE "https://github.com/hina-shah/SlicerBatchAnonymize")
 set(EXTENSION_CATEGORY "DSCI")
-set(EXTENSION_CONTRIBUTORS "Hina Shah (UNC Chapel Hill)")
+set(EXTENSION_CONTRIBUTORS "Hina Shah (UNC Chapel Hill), Juan Carlos Prieto (UNC, Chapel Hill)")
 set(EXTENSION_DESCRIPTION "SlicerBatchAnonymize is a Slicer extension that provides a user friendly interface to anonymize a 'batch' of DICOM images.")
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/hina-shah/SlicerBatchAnonymize/main/SlicerBatchAnonymize.png")
 set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/hina-shah/SlicerBatchAnonymize/main/Documentation/GUIPreview.png")


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.